### PR TITLE
fix: fetch lazy dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation {
       package_dirs_checked+=("$package")
 
       if [ -e "$package/build.zig.zon" ]; then
+        sed -i '/^\s*\.lazy\s*=\s*true\s*,\s*$/d' "$package/build.zig.zon"
+
         cd "$package" || exit 1
         zig build --fetch --global-cache-dir "$zig_cache" --cache-dir "$zig_cache"
         for dir in "$zig_cache"/p/*; do

--- a/default.nix
+++ b/default.nix
@@ -21,13 +21,39 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
-    zig build --fetch --global-cache-dir ".zig-cache" --cache-dir ".zig-cache"
+
+    root_dir=$PWD
+    zig_cache="$PWD/.zig-cache"
+
+    package_dirs_checked=()
+
+    function fetchDepsForPackage() {
+      package="$1"
+
+      if [[ "''${package_dirs_checked[*]}" =~ $package ]]; then
+        return 0
+      fi
+      package_dirs_checked+=("$package")
+
+      if [ -e "$package/build.zig.zon" ]; then
+        cd "$package" || exit 1
+        zig build --fetch --global-cache-dir "$zig_cache" --cache-dir "$zig_cache"
+        for dir in "$zig_cache"/p/*; do
+          fetchDepsForPackage "$dir"
+        done
+      fi
+    }
+
+    fetchDepsForPackage .
+
+    cd $root_dir
+
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    cp -r --reflink=auto .zig-cache/p $out
+    cp -r --reflink=auto "${packageRoot}/.zig-cache/p" $out
     runHook postInstall
   '';
 


### PR DESCRIPTION
`zig build --fetch` does not fetch all dependencies that are required at build time. Lazy dependencies are the problem here; they only get fetched during the build phase, instead of getting prefetched.

This manually goes into each directory, checks if a `build.zig.zon` exists there. and then runs `zig build --fetch` again after removing these lines using `sed` (horrible, I know). While this is a rather crude hack, and may get slow for some packages, it should work for now.

Ideally, there should be a way to recursively fetch all packages using `zig build --fetch=eager` (well, after looking for a bit, there is https://github.com/ziglang/zig/pull/19975, which could get rid of this hack entirely if merged).

Closes #1.